### PR TITLE
SFD-2348 Create API service layer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@
   - [Merge request](#merge-request)
     - [GitLab web interface](#gitlab-web-interface)
   - [Code review](#code-review)
+  - [Unit tests](#unit-tests)
 
 ## Development Environment
 
@@ -178,3 +179,22 @@ If JIRA is currently not in use to track project changes, please drop any refere
 ## Code review
 
 Please, refer to the [Clean Code](https://learning.oreilly.com/library/view/clean-code/9780136083238/), especially chapter 17 and [Clean Architecture](https://learning.oreilly.com/library/view/clean-architecture-a/9780134494272/) books by Robert C. Martin while performing peer code reviews.
+
+## Unit tests
+
+When writing or updating unit tests, please always structure them using the 3 A's approach of 'Arrange', 'Act', and 'Assert'. For example:
+
+    @Test
+    public void retrieveServicesByFuzzySearchNullReturn() {
+    // Arrange
+    List<String> searchCriteria = new ArrayList<>();
+    searchCriteria.add("Null");
+    when(serviceRepository.findServiceBySearchTerms(searchCriteria)).thenReturn(null);
+
+    // Act
+    List<DosService> services =
+        fuzzyServiceSearchService.retrieveServicesByFuzzySearch(searchCriteria);
+
+    // Assert
+    assertEquals(0, services.size());
+    }

--- a/application/app/src/main/java/uk/nhs/digital/uec/api/repository/elasticsearch/ServicesRepositoryInterface.java
+++ b/application/app/src/main/java/uk/nhs/digital/uec/api/repository/elasticsearch/ServicesRepositoryInterface.java
@@ -1,0 +1,15 @@
+package uk.nhs.digital.uec.api.repository.elasticsearch;
+
+import java.util.List;
+import uk.nhs.digital.uec.api.model.DosService;
+
+public interface ServicesRepositoryInterface {
+
+  /**
+   * Returns a list of Dos Services that match the specified search criteria.
+   *
+   * @param searchTerms a list of terms to match the services to.
+   * @return list of Dos Services that match the search criteria.
+   */
+  List<DosService> findServiceBySearchTerms(List<String> searchTerms);
+}

--- a/application/app/src/main/java/uk/nhs/digital/uec/api/repository/elasticsearch/impl/ServiceRepository.java
+++ b/application/app/src/main/java/uk/nhs/digital/uec/api/repository/elasticsearch/impl/ServiceRepository.java
@@ -1,0 +1,23 @@
+package uk.nhs.digital.uec.api.repository.elasticsearch.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
+import uk.nhs.digital.uec.api.model.DosService;
+import uk.nhs.digital.uec.api.repository.elasticsearch.ServicesRepositoryInterface;
+
+@Profile("prod")
+@Repository
+public class ServiceRepository implements ServicesRepositoryInterface {
+
+  /** {@inheritDoc} */
+  @Override
+  public List<DosService> findServiceBySearchTerms(List<String> searchTerms) {
+    final List<DosService> dosServices = new ArrayList<>();
+
+    // TODO - IMPLEMENT ME.
+
+    return dosServices;
+  }
+}

--- a/application/app/src/main/java/uk/nhs/digital/uec/api/service/FuzzyServiceSearchServiceInterface.java
+++ b/application/app/src/main/java/uk/nhs/digital/uec/api/service/FuzzyServiceSearchServiceInterface.java
@@ -9,9 +9,9 @@ public interface FuzzyServiceSearchServiceInterface {
   /**
    * Returns a list of {@link DosService} for the search criteria provided.
    *
-   * @param searchString the search criteria to look for matching services. Services will be matched
-   *     by: name public name address postcode
+   * @param searchTerms the search terms to look for matching services. Services will be matched by:
+   *     name public name address postcode
    * @return {@link DosService}
    */
-  public List<DosService> retrieveServicesByFuzzySearch(final List<String> searchString);
+  List<DosService> retrieveServicesByFuzzySearch(final List<String> searchTerms);
 }

--- a/application/app/src/main/java/uk/nhs/digital/uec/api/service/impl/FuzzyServiceSearchService.java
+++ b/application/app/src/main/java/uk/nhs/digital/uec/api/service/impl/FuzzyServiceSearchService.java
@@ -2,26 +2,32 @@ package uk.nhs.digital.uec.api.service.impl;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.nhs.digital.uec.api.model.DosService;
+import uk.nhs.digital.uec.api.repository.elasticsearch.ServicesRepositoryInterface;
 import uk.nhs.digital.uec.api.service.FuzzyServiceSearchServiceInterface;
-import uk.nhs.digital.uec.api.utils.MockDosServicesUtil;
 
 @Service
 public class FuzzyServiceSearchService implements FuzzyServiceSearchServiceInterface {
 
+  @Autowired private ServicesRepositoryInterface elasticsearch;
+
+  @Value("${param.services.max_num_services_to_return}")
+  private int maxNumServicesToReturn;
+
   /** {@inheritDoc} */
   @Override
-  public List<DosService> retrieveServicesByFuzzySearch(final List<String> searchCriteria) {
+  public List<DosService> retrieveServicesByFuzzySearch(final List<String> searchTerms) {
 
-    List<DosService> dosServices = new ArrayList<>();
+    final List<DosService> dosServices = new ArrayList<>();
+    if (elasticsearch.findServiceBySearchTerms(searchTerms) != null) {
+      dosServices.addAll(elasticsearch.findServiceBySearchTerms(searchTerms));
+    }
 
-    // If "Term0" is included in the search criteria, return no services, otherwise return the whole
-    // set.
-    if (!searchCriteria.contains("Term0")) {
-      // Add the mock services we want to return:
-      dosServices.add(MockDosServicesUtil.mockDosServices.get(1));
-      dosServices.add(MockDosServicesUtil.mockDosServices.get(2));
+    if (dosServices.size() > maxNumServicesToReturn) {
+      return dosServices.subList(0, maxNumServicesToReturn);
     }
 
     return dosServices;

--- a/application/app/src/main/java/uk/nhs/digital/uec/api/service/impl/ValidationService.java
+++ b/application/app/src/main/java/uk/nhs/digital/uec/api/service/impl/ValidationService.java
@@ -9,8 +9,8 @@ import uk.nhs.digital.uec.api.service.ValidationServiceInterface;
 @Service
 public class ValidationService implements ValidationServiceInterface {
 
-  @Value("${param.validation.min_search_string_length}")
-  private int minSearchStringLength;
+  @Value("${param.validation.min_search_term_length}")
+  private int minSearchTermLength;
 
   @Value("${param.validation.max_search_criteria}")
   private int maxSearchCriteria;
@@ -53,7 +53,7 @@ public class ValidationService implements ValidationServiceInterface {
     boolean minSearchCriteriaLthMet = false;
 
     for (final String searchCriteriaStr : searchCriteria) {
-      if (searchCriteriaStr.length() >= minSearchStringLength) {
+      if (searchCriteriaStr.length() >= minSearchTermLength) {
         minSearchCriteriaLthMet = true;
         break;
       }

--- a/application/app/src/main/resources/application.yaml
+++ b/application/app/src/main/resources/application.yaml
@@ -1,13 +1,13 @@
 server:
-  port: 9095
+  port: ${SERVER_PORT}
 
 api:
-  endpoint: "http://localhost:9095/dosapi/dosservices/v0.0.1/services/byfuzzysearch"
+  endpoint: ${URL}
 
 param:
-  version: "0.0.1"
+  version: ${VERSION}
   validation:
-    min_search_string_length: 3
-    max_search_criteria: 4
+    min_search_term_length: ${MIN_SEARCH_TERM_LENGTH}
+    max_search_criteria: ${MAX_SEARCH_CRITERIA}
   services:
-    max_num_services_to_return: 20
+    max_num_services_to_return: ${MAX_NUM_SERVICES_TO_RETURN}

--- a/application/app/src/main/resources/application.yaml
+++ b/application/app/src/main/resources/application.yaml
@@ -9,3 +9,5 @@ param:
   validation:
     min_search_string_length: 3
     max_search_criteria: 4
+  services:
+    max_num_services_to_return: 20

--- a/application/app/src/test/java/uk/nhs/digital/uec/api/controller/FuzzySearchControllerTest.java
+++ b/application/app/src/test/java/uk/nhs/digital/uec/api/controller/FuzzySearchControllerTest.java
@@ -40,16 +40,19 @@ public class FuzzySearchControllerTest {
 
   @Test
   public void getServicesByFuzzySearchTestSucc() throws ValidationException {
+    // Arrange
     List<String> searchCriteria = new ArrayList<>();
     searchCriteria.add("term1");
     searchCriteria.add("term2");
 
+    // Act
     when(mockFuzzyServiceSearchService.retrieveServicesByFuzzySearch(searchCriteria))
         .thenReturn(getDosServices());
 
     ResponseEntity<ApiResponse> responseEntity =
         fuzzyServiceSearchController.getServicesByFuzzySearch(searchCriteria, null);
 
+    // Assert
     final ApiSuccessResponse response = (ApiSuccessResponse) responseEntity.getBody();
     final List<DosService> returnedServices = response.getServices();
 
@@ -66,10 +69,12 @@ public class FuzzySearchControllerTest {
 
   @Test
   public void getServicesByFuzzySearchTestValidationError() throws ValidationException {
+    // Arrange
     List<String> searchCriteria = new ArrayList<>();
     searchCriteria.add("term1");
     searchCriteria.add("term2");
 
+    // Act
     doThrow(new ValidationException(VALIDATION_ERROR_MSG, VALIDATION_ERROR_CODE))
         .when(mockValidationService)
         .validateSearchCriteria(searchCriteria);
@@ -77,6 +82,7 @@ public class FuzzySearchControllerTest {
     ResponseEntity<ApiResponse> responseEntity =
         fuzzyServiceSearchController.getServicesByFuzzySearch(searchCriteria, null);
 
+    // Assert
     final ApiValidationErrorResponse response =
         (ApiValidationErrorResponse) responseEntity.getBody();
 

--- a/application/app/src/test/java/uk/nhs/digital/uec/api/controller/FuzzySearchControllerTest.java
+++ b/application/app/src/test/java/uk/nhs/digital/uec/api/controller/FuzzySearchControllerTest.java
@@ -24,7 +24,7 @@ import uk.nhs.digital.uec.api.model.ApiValidationErrorResponse;
 import uk.nhs.digital.uec.api.model.DosService;
 import uk.nhs.digital.uec.api.service.impl.FuzzyServiceSearchService;
 import uk.nhs.digital.uec.api.service.impl.ValidationService;
-import uk.nhs.digital.uec.api.utils.MockDosServicesUtil;
+import uk.nhs.digital.uec.api.util.MockDosServicesUtil;
 
 @ExtendWith(SpringExtension.class)
 public class FuzzySearchControllerTest {

--- a/application/app/src/test/java/uk/nhs/digital/uec/api/integration/fuzzysearch/FuzzySearchGeneralErrorsTest.java
+++ b/application/app/src/test/java/uk/nhs/digital/uec/api/integration/fuzzysearch/FuzzySearchGeneralErrorsTest.java
@@ -38,40 +38,56 @@ public class FuzzySearchGeneralErrorsTest {
   /** Given a Post call on the endpoint, ensure a 405 error is returned. */
   @Test
   public void postCallOnEndpoint() throws Exception {
+    // Arrange
     HttpEntity<String> request = new HttpEntity<String>(null, headers);
+
+    // Act
     ResponseEntity<String> response =
         restTemplate.exchange(endpointUrl, HttpMethod.POST, request, String.class);
 
+    // Assert
     assertTrue(response.getStatusCode() == HttpStatus.METHOD_NOT_ALLOWED);
   }
 
   /** Given a Patch call on the endpoint, ensure a 405 error is returned. */
   @Test
   public void patchCallOnEndpoint() throws Exception {
+    // Arrange
     HttpEntity<String> request = new HttpEntity<String>(null, headers);
+
+    // Act
     ResponseEntity<String> response =
         restTemplate.exchange(endpointUrl, HttpMethod.PATCH, request, String.class);
 
+    // Assert
     assertTrue(response.getStatusCode() == HttpStatus.METHOD_NOT_ALLOWED);
   }
 
   /** Given a Put call on the endpoint, ensure a 405 error is returned. */
   @Test
   public void putCallOnEndpoint() throws Exception {
+    // Arrange
     HttpEntity<String> request = new HttpEntity<String>(null, headers);
+
+    // Act
     ResponseEntity<String> response =
         restTemplate.exchange(endpointUrl, HttpMethod.PUT, request, String.class);
 
+    // Assert
     assertTrue(response.getStatusCode() == HttpStatus.METHOD_NOT_ALLOWED);
   }
 
   /** Given a Delete call on the endpoint, ensure a 405 error is returned. */
   @Test
   public void deleteCallOnEndpoint() throws Exception {
+    // Arrange
     HttpEntity<String> request = new HttpEntity<String>(null, headers);
+
+    // Act
     ResponseEntity<String> response =
         restTemplate.exchange(endpointUrl, HttpMethod.DELETE, request, String.class);
 
+    // Assert
     assertTrue(response.getStatusCode() == HttpStatus.METHOD_NOT_ALLOWED);
   }
 }

--- a/application/app/src/test/java/uk/nhs/digital/uec/api/integration/fuzzysearch/FuzzySearchGeneralErrorsTest.java
+++ b/application/app/src/test/java/uk/nhs/digital/uec/api/integration/fuzzysearch/FuzzySearchGeneralErrorsTest.java
@@ -12,8 +12,10 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
 import uk.nhs.digital.uec.api.util.PropertySourceResolver;
 
+@ActiveProfiles("test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 /**
  * Test class which passes requests through the Fuzzy Search endpoint and asserts desired API

--- a/application/app/src/test/java/uk/nhs/digital/uec/api/integration/fuzzysearch/FuzzySearchGeneralErrorsTest.java
+++ b/application/app/src/test/java/uk/nhs/digital/uec/api/integration/fuzzysearch/FuzzySearchGeneralErrorsTest.java
@@ -15,12 +15,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
 import uk.nhs.digital.uec.api.util.PropertySourceResolver;
 
-@ActiveProfiles("test")
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 /**
  * Test class which passes requests through the Fuzzy Search endpoint and asserts desired API
  * behavior. Only the model layer will be mocked here.
  */
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 public class FuzzySearchGeneralErrorsTest {
 
   @Autowired private PropertySourceResolver propertySourceResolver;

--- a/application/app/src/test/java/uk/nhs/digital/uec/api/integration/fuzzysearch/FuzzySearchSuccessTest.java
+++ b/application/app/src/test/java/uk/nhs/digital/uec/api/integration/fuzzysearch/FuzzySearchSuccessTest.java
@@ -23,12 +23,12 @@ import uk.nhs.digital.uec.api.model.DosService;
 import uk.nhs.digital.uec.api.util.MockDosServicesUtil;
 import uk.nhs.digital.uec.api.util.PropertySourceResolver;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
-@ActiveProfiles("test")
 /**
  * Test class which passes requests through the Fuzzy Search endpoint and asserts desired API
  * behavior. Only the model layer will be mocked here.
  */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@ActiveProfiles("test")
 public class FuzzySearchSuccessTest {
 
   @Autowired private ObjectMapper mapper;

--- a/application/app/src/test/java/uk/nhs/digital/uec/api/integration/fuzzysearch/FuzzySearchSuccessTest.java
+++ b/application/app/src/test/java/uk/nhs/digital/uec/api/integration/fuzzysearch/FuzzySearchSuccessTest.java
@@ -57,12 +57,16 @@ public class FuzzySearchSuccessTest {
    */
   @Test
   public void oneSearchCriteriaGiven() throws Exception {
+    // Arrange
     HttpEntity<String> request = new HttpEntity<String>(null, headers);
     UriComponentsBuilder uriBuilder =
         UriComponentsBuilder.fromHttpUrl(endpointUrl).queryParam("search_criteria", "Term1");
+
+    // Act
     ResponseEntity<String> responseEntity =
         restTemplate.exchange(uriBuilder.toUriString(), HttpMethod.GET, request, String.class);
 
+    // Assert
     assertTrue(responseEntity.getStatusCode() == HttpStatus.OK);
 
     ApiSuccessResponse response =
@@ -86,15 +90,19 @@ public class FuzzySearchSuccessTest {
    */
   @Test
   public void atLeastOneValidSearchTermGiven() throws Exception {
+    // Arrange
     HttpEntity<String> request = new HttpEntity<String>(null, headers);
     UriComponentsBuilder uriBuilder =
         UriComponentsBuilder.fromHttpUrl(endpointUrl)
             .queryParam("search_criteria", "a")
             .queryParam("search_criteria", "ab")
             .queryParam("search_criteria", "Term1");
+
+    // Act
     ResponseEntity<String> responseEntity =
         restTemplate.exchange(uriBuilder.toUriString(), HttpMethod.GET, request, String.class);
 
+    // Assert
     assertTrue(responseEntity.getStatusCode() == HttpStatus.OK);
 
     ApiSuccessResponse response =
@@ -118,12 +126,16 @@ public class FuzzySearchSuccessTest {
    */
   @Test
   public void oneSearchCriteriaGivenNoResults() throws Exception {
+    // Arrange
     HttpEntity<String> request = new HttpEntity<String>(null, headers);
     UriComponentsBuilder uriBuilder =
         UriComponentsBuilder.fromHttpUrl(endpointUrl).queryParam("search_criteria", "Term0");
+
+    // Act
     ResponseEntity<String> responseEntity =
         restTemplate.exchange(uriBuilder.toUriString(), HttpMethod.GET, request, String.class);
 
+    // Assert
     assertTrue(responseEntity.getStatusCode() == HttpStatus.OK);
 
     ApiSuccessResponse response =
@@ -135,12 +147,16 @@ public class FuzzySearchSuccessTest {
   /** Given search criteria of ALL, return the maximum number of services. */
   @Test
   public void allSearchCriteriaGivenMaxResults() throws Exception {
+    // Arrange
     HttpEntity<String> request = new HttpEntity<String>(null, headers);
     UriComponentsBuilder uriBuilder =
         UriComponentsBuilder.fromHttpUrl(endpointUrl).queryParam("search_criteria", "All");
+
+    // Act
     ResponseEntity<String> responseEntity =
         restTemplate.exchange(uriBuilder.toUriString(), HttpMethod.GET, request, String.class);
 
+    // Assert
     assertTrue(responseEntity.getStatusCode() == HttpStatus.OK);
 
     ApiSuccessResponse response =

--- a/application/app/src/test/java/uk/nhs/digital/uec/api/integration/fuzzysearch/FuzzySearchValidationErrorsTest.java
+++ b/application/app/src/test/java/uk/nhs/digital/uec/api/integration/fuzzysearch/FuzzySearchValidationErrorsTest.java
@@ -47,10 +47,14 @@ public class FuzzySearchValidationErrorsTest {
    */
   @Test
   public void noSearchCriteriaGiven() throws Exception {
+    // Arrange
     HttpEntity<String> request = new HttpEntity<String>(null, headers);
+
+    // Act
     ResponseEntity<String> responseEntity =
         restTemplate.exchange(endpointUrl, HttpMethod.GET, request, String.class);
 
+    // Assert
     assertTrue(responseEntity.getStatusCode() == HttpStatus.BAD_REQUEST);
 
     ApiValidationErrorResponse response =
@@ -65,6 +69,7 @@ public class FuzzySearchValidationErrorsTest {
    */
   @Test
   public void tooManySearchCriteriaGiven() throws Exception {
+    // Arrange
     HttpEntity<String> request = new HttpEntity<String>(null, headers);
     UriComponentsBuilder uriBuilder =
         UriComponentsBuilder.fromHttpUrl(endpointUrl)
@@ -74,9 +79,12 @@ public class FuzzySearchValidationErrorsTest {
             .queryParam("search_criteria", "Term4")
             .queryParam("search_criteria", "Term5")
             .queryParam("search_criteria", "Term6");
+
+    // Act
     ResponseEntity<String> responseEntity =
         restTemplate.exchange(uriBuilder.toUriString(), HttpMethod.GET, request, String.class);
 
+    // Assert
     assertTrue(responseEntity.getStatusCode() == HttpStatus.BAD_REQUEST);
 
     ApiValidationErrorResponse response =
@@ -91,15 +99,19 @@ public class FuzzySearchValidationErrorsTest {
    */
   @Test
   public void noSearchTermMeetsRequirements() throws Exception {
+    // Arrange
     HttpEntity<String> request = new HttpEntity<String>(null, headers);
     UriComponentsBuilder uriBuilder =
         UriComponentsBuilder.fromHttpUrl(endpointUrl)
             .queryParam("search_criteria", "1")
             .queryParam("search_criteria", "ab")
             .queryParam("search_criteria", "z");
+
+    // Act
     ResponseEntity<String> responseEntity =
         restTemplate.exchange(uriBuilder.toUriString(), HttpMethod.GET, request, String.class);
 
+    // Assert
     assertTrue(responseEntity.getStatusCode() == HttpStatus.BAD_REQUEST);
 
     ApiValidationErrorResponse response =

--- a/application/app/src/test/java/uk/nhs/digital/uec/api/integration/fuzzysearch/FuzzySearchValidationErrorsTest.java
+++ b/application/app/src/test/java/uk/nhs/digital/uec/api/integration/fuzzysearch/FuzzySearchValidationErrorsTest.java
@@ -14,10 +14,12 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.util.UriComponentsBuilder;
 import uk.nhs.digital.uec.api.model.ApiValidationErrorResponse;
 import uk.nhs.digital.uec.api.util.PropertySourceResolver;
 
+@ActiveProfiles("test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 /**
  * Test class which passes requests through the Fuzzy Search endpoint and asserts desired API

--- a/application/app/src/test/java/uk/nhs/digital/uec/api/integration/fuzzysearch/FuzzySearchValidationErrorsTest.java
+++ b/application/app/src/test/java/uk/nhs/digital/uec/api/integration/fuzzysearch/FuzzySearchValidationErrorsTest.java
@@ -19,12 +19,12 @@ import org.springframework.web.util.UriComponentsBuilder;
 import uk.nhs.digital.uec.api.model.ApiValidationErrorResponse;
 import uk.nhs.digital.uec.api.util.PropertySourceResolver;
 
-@ActiveProfiles("test")
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 /**
  * Test class which passes requests through the Fuzzy Search endpoint and asserts desired API
  * behavior. Only the model layer will be mocked here.
  */
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 public class FuzzySearchValidationErrorsTest {
 
   @Autowired private ObjectMapper mapper;

--- a/application/app/src/test/java/uk/nhs/digital/uec/api/repository/elasticsearch/mock/ServiceRepositoryMock.java
+++ b/application/app/src/test/java/uk/nhs/digital/uec/api/repository/elasticsearch/mock/ServiceRepositoryMock.java
@@ -1,0 +1,35 @@
+package uk.nhs.digital.uec.api.repository.elasticsearch.mock;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
+import uk.nhs.digital.uec.api.model.DosService;
+import uk.nhs.digital.uec.api.repository.elasticsearch.ServicesRepositoryInterface;
+import uk.nhs.digital.uec.api.util.MockDosServicesUtil;
+
+@Repository
+@Profile("test")
+public class ServiceRepositoryMock implements ServicesRepositoryInterface {
+
+  /** {@inheritDoc} */
+  @Override
+  public List<DosService> findServiceBySearchTerms(List<String> searchTerms) {
+    final List<DosService> dosServices = new ArrayList<>();
+
+    if (!searchTerms.contains("Term0")) {
+      dosServices.add(MockDosServicesUtil.mockDosServices.get(1));
+      dosServices.add(MockDosServicesUtil.mockDosServices.get(2));
+    }
+
+    if (searchTerms.contains("All")) {
+
+      for (Map.Entry<Integer, DosService> entry : MockDosServicesUtil.mockDosServices.entrySet()) {
+        dosServices.add(entry.getValue());
+      }
+    }
+
+    return dosServices;
+  }
+}

--- a/application/app/src/test/java/uk/nhs/digital/uec/api/service/ApiUtilsServiceTest.java
+++ b/application/app/src/test/java/uk/nhs/digital/uec/api/service/ApiUtilsServiceTest.java
@@ -18,7 +18,7 @@ public class ApiUtilsServiceTest {
 
   @Test
   public void sanitiseSearchTerms() {
-
+    // Arrange
     final List<String> searchCriteria = new ArrayList<>();
     searchCriteria.add("term1");
     searchCriteria.add("   term2");
@@ -27,9 +27,11 @@ public class ApiUtilsServiceTest {
     searchCriteria.add("term 5");
     searchCriteria.add("  term 6  ");
 
+    // Act
     final List<String> sanitisedSearchCriteria =
         apiUtilsService.sanitiseSearchTerms(searchCriteria);
 
+    // Assert
     assertTrue(sanitisedSearchCriteria.contains("term1"));
     assertTrue(sanitisedSearchCriteria.contains("term2"));
     assertTrue(sanitisedSearchCriteria.contains("term3"));

--- a/application/app/src/test/java/uk/nhs/digital/uec/api/service/FuzzyServiceSearchServiceTest.java
+++ b/application/app/src/test/java/uk/nhs/digital/uec/api/service/FuzzyServiceSearchServiceTest.java
@@ -35,7 +35,7 @@ public class FuzzyServiceSearchServiceTest {
 
   @Test
   public void retrieveServicesByFuzzySearchSuccess() {
-
+    // Arrange
     List<String> searchCriteria = new ArrayList<>();
     searchCriteria.add("term1");
     searchCriteria.add("term2");
@@ -46,15 +46,17 @@ public class FuzzyServiceSearchServiceTest {
 
     when(serviceRepository.findServiceBySearchTerms(searchCriteria)).thenReturn(dosServices);
 
+    // Act
     List<DosService> services =
         fuzzyServiceSearchService.retrieveServicesByFuzzySearch(searchCriteria);
 
+    // Assert
     assertEquals(2, services.size());
   }
 
   @Test
   public void retrieveServicesByFuzzySearchNoResults() {
-
+    // Arrange
     List<String> searchCriteria = new ArrayList<>();
     searchCriteria.add("term0");
 
@@ -62,15 +64,17 @@ public class FuzzyServiceSearchServiceTest {
 
     when(serviceRepository.findServiceBySearchTerms(searchCriteria)).thenReturn(dosServices);
 
+    // Act
     List<DosService> services =
         fuzzyServiceSearchService.retrieveServicesByFuzzySearch(searchCriteria);
 
+    // Assert
     assertEquals(0, services.size());
   }
 
   @Test
   public void retrieveServicesByFuzzySearchTooManyResults() {
-
+    // Arrange
     List<String> searchCriteria = new ArrayList<>();
     searchCriteria.add("All");
 
@@ -81,15 +85,17 @@ public class FuzzyServiceSearchServiceTest {
 
     when(serviceRepository.findServiceBySearchTerms(searchCriteria)).thenReturn(dosServices);
 
+    // Act
     List<DosService> services =
         fuzzyServiceSearchService.retrieveServicesByFuzzySearch(searchCriteria);
 
+    // Assert
     assertEquals(maxNumServicesToReturn, services.size());
   }
 
   @Test
   public void retrieveServicesByFuzzySearchMaxReturn() {
-
+    // Arrange
     List<String> searchCriteria = new ArrayList<>();
     searchCriteria.add("Max");
 
@@ -101,23 +107,27 @@ public class FuzzyServiceSearchServiceTest {
 
     when(serviceRepository.findServiceBySearchTerms(searchCriteria)).thenReturn(maxDosServices);
 
+    // Act
     List<DosService> services =
         fuzzyServiceSearchService.retrieveServicesByFuzzySearch(searchCriteria);
 
+    // Assert
     assertEquals(maxNumServicesToReturn, services.size());
   }
 
   @Test
   public void retrieveServicesByFuzzySearchNullReturn() {
-
+    // Arrange
     List<String> searchCriteria = new ArrayList<>();
     searchCriteria.add("Null");
 
     when(serviceRepository.findServiceBySearchTerms(searchCriteria)).thenReturn(null);
 
+    // Act
     List<DosService> services =
         fuzzyServiceSearchService.retrieveServicesByFuzzySearch(searchCriteria);
 
+    // Assert
     assertEquals(0, services.size());
   }
 }

--- a/application/app/src/test/java/uk/nhs/digital/uec/api/service/FuzzyServiceSearchServiceTest.java
+++ b/application/app/src/test/java/uk/nhs/digital/uec/api/service/FuzzyServiceSearchServiceTest.java
@@ -1,31 +1,123 @@
 package uk.nhs.digital.uec.api.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 import uk.nhs.digital.uec.api.model.DosService;
+import uk.nhs.digital.uec.api.repository.elasticsearch.impl.ServiceRepository;
 import uk.nhs.digital.uec.api.service.impl.FuzzyServiceSearchService;
+import uk.nhs.digital.uec.api.util.MockDosServicesUtil;
 
 @ExtendWith(SpringExtension.class)
 public class FuzzyServiceSearchServiceTest {
 
+  private int maxNumServicesToReturn = 10;
+
   @InjectMocks private FuzzyServiceSearchService fuzzyServiceSearchService;
 
+  @Mock private ServiceRepository serviceRepository;
+
+  @BeforeEach
+  public void setup() {
+    ReflectionTestUtils.setField(
+        fuzzyServiceSearchService, "maxNumServicesToReturn", maxNumServicesToReturn);
+  }
+
   @Test
-  public void retrieveServicesByFuzzySearchTest() {
+  public void retrieveServicesByFuzzySearchSuccess() {
 
     List<String> searchCriteria = new ArrayList<>();
     searchCriteria.add("term1");
     searchCriteria.add("term2");
 
+    List<DosService> dosServices = new ArrayList<>();
+    dosServices.add(MockDosServicesUtil.mockDosServices.get(1));
+    dosServices.add(MockDosServicesUtil.mockDosServices.get(2));
+
+    when(serviceRepository.findServiceBySearchTerms(searchCriteria)).thenReturn(dosServices);
+
     List<DosService> services =
         fuzzyServiceSearchService.retrieveServicesByFuzzySearch(searchCriteria);
 
     assertEquals(2, services.size());
+  }
+
+  @Test
+  public void retrieveServicesByFuzzySearchNoResults() {
+
+    List<String> searchCriteria = new ArrayList<>();
+    searchCriteria.add("term0");
+
+    List<DosService> dosServices = new ArrayList<>();
+
+    when(serviceRepository.findServiceBySearchTerms(searchCriteria)).thenReturn(dosServices);
+
+    List<DosService> services =
+        fuzzyServiceSearchService.retrieveServicesByFuzzySearch(searchCriteria);
+
+    assertEquals(0, services.size());
+  }
+
+  @Test
+  public void retrieveServicesByFuzzySearchTooManyResults() {
+
+    List<String> searchCriteria = new ArrayList<>();
+    searchCriteria.add("All");
+
+    List<DosService> dosServices = new ArrayList<>();
+    for (Map.Entry<Integer, DosService> entry : MockDosServicesUtil.mockDosServices.entrySet()) {
+      dosServices.add(entry.getValue());
+    }
+
+    when(serviceRepository.findServiceBySearchTerms(searchCriteria)).thenReturn(dosServices);
+
+    List<DosService> services =
+        fuzzyServiceSearchService.retrieveServicesByFuzzySearch(searchCriteria);
+
+    assertEquals(maxNumServicesToReturn, services.size());
+  }
+
+  @Test
+  public void retrieveServicesByFuzzySearchMaxReturn() {
+
+    List<String> searchCriteria = new ArrayList<>();
+    searchCriteria.add("Max");
+
+    List<DosService> dosServices = new ArrayList<>();
+    for (Map.Entry<Integer, DosService> entry : MockDosServicesUtil.mockDosServices.entrySet()) {
+      dosServices.add(entry.getValue());
+    }
+    List<DosService> maxDosServices = dosServices.subList(0, maxNumServicesToReturn);
+
+    when(serviceRepository.findServiceBySearchTerms(searchCriteria)).thenReturn(maxDosServices);
+
+    List<DosService> services =
+        fuzzyServiceSearchService.retrieveServicesByFuzzySearch(searchCriteria);
+
+    assertEquals(maxNumServicesToReturn, services.size());
+  }
+
+  @Test
+  public void retrieveServicesByFuzzySearchNullReturn() {
+
+    List<String> searchCriteria = new ArrayList<>();
+    searchCriteria.add("Null");
+
+    when(serviceRepository.findServiceBySearchTerms(searchCriteria)).thenReturn(null);
+
+    List<DosService> services =
+        fuzzyServiceSearchService.retrieveServicesByFuzzySearch(searchCriteria);
+
+    assertEquals(0, services.size());
   }
 }

--- a/application/app/src/test/java/uk/nhs/digital/uec/api/service/ValidationServiceTest.java
+++ b/application/app/src/test/java/uk/nhs/digital/uec/api/service/ValidationServiceTest.java
@@ -19,22 +19,23 @@ public class ValidationServiceTest {
 
   @InjectMocks private ValidationService validationService;
 
-  private int minSearchStringLength = 3;
+  private int minSearchTermLength = 3;
 
   private int maxSearchCriteria = 10;
 
   @BeforeEach
   public void setup() {
-    ReflectionTestUtils.setField(validationService, "minSearchStringLength", minSearchStringLength);
+    ReflectionTestUtils.setField(validationService, "minSearchTermLength", minSearchTermLength);
     ReflectionTestUtils.setField(validationService, "maxSearchCriteria", maxSearchCriteria);
   }
 
   @Test
   public void validateSearchCriteriaMinSuccess() {
-
+    // Arrange
     final List<String> searchCriteria = new ArrayList<>();
     searchCriteria.add("term1");
 
+    // Act and Assert
     try {
       validationService.validateSearchCriteria(searchCriteria);
     } catch (ValidationException ve) {
@@ -44,12 +45,13 @@ public class ValidationServiceTest {
 
   @Test
   public void validateSearchCriteriaSuccess() {
-
+    // Arrange
     final List<String> searchCriteria = new ArrayList<>();
     searchCriteria.add("term1");
     searchCriteria.add("term2");
     searchCriteria.add("term3");
 
+    // Act and Assert
     try {
       validationService.validateSearchCriteria(searchCriteria);
     } catch (ValidationException ve) {
@@ -59,12 +61,13 @@ public class ValidationServiceTest {
 
   @Test
   public void validateSearchCriteriaLimitSuccess() {
-
+    // Arrange
     final List<String> searchCriteria = new ArrayList<>();
     for (int i = 0; i < maxSearchCriteria; i++) {
       searchCriteria.add("term" + i);
     }
 
+    // Act and Assert
     try {
       validationService.validateSearchCriteria(searchCriteria);
     } catch (ValidationException ve) {
@@ -74,9 +77,10 @@ public class ValidationServiceTest {
 
   @Test
   public void validateSearchCriteriaEmpty() {
-
+    // Arrange
     final List<String> searchCriteria = new ArrayList<>();
 
+    // Act and Assert
     try {
       validationService.validateSearchCriteria(searchCriteria);
       fail("No validation exception raised when expected because the search criteria is empty.");
@@ -89,7 +93,7 @@ public class ValidationServiceTest {
 
   @Test
   public void validateSearchCriteriaNull() {
-
+    // Act and Assert
     try {
       validationService.validateSearchCriteria(null);
       fail("No validation exception raised when expected because the search criteria is empty.");
@@ -102,13 +106,14 @@ public class ValidationServiceTest {
 
   @Test
   public void validateSearchCriteriaTooManyTerms() {
-
+    // Arrange
     final List<String> searchCriteria = new ArrayList<>();
 
     for (int i = 0; i < maxSearchCriteria + 1; i++) {
       searchCriteria.add("term" + i);
     }
 
+    // Act and Assert
     try {
       validationService.validateSearchCriteria(searchCriteria);
       fail(
@@ -123,10 +128,11 @@ public class ValidationServiceTest {
 
   @Test
   public void validateMinSearchTermLengthSuccess() {
-
+    // Arrange
     final List<String> searchCriteria = new ArrayList<>();
     searchCriteria.add("123");
 
+    // Act and Assert
     try {
       validationService.validateMinSearchCriteriaLength(searchCriteria);
     } catch (ValidationException ve) {
@@ -136,12 +142,13 @@ public class ValidationServiceTest {
 
   @Test
   public void validateMinSearchTermLengthOneTermValidSuccess() {
-
+    // Arrange
     final List<String> searchCriteria = new ArrayList<>();
     searchCriteria.add("1");
     searchCriteria.add("12");
     searchCriteria.add("123");
 
+    // Act and Assert
     try {
       validationService.validateMinSearchCriteriaLength(searchCriteria);
     } catch (ValidationException ve) {
@@ -151,9 +158,10 @@ public class ValidationServiceTest {
 
   @Test
   public void validateSearchCriteriaLengthEmpty() {
-
+    // Arrange
     final List<String> searchCriteria = new ArrayList<>();
 
+    // Act and Assert
     try {
       validationService.validateMinSearchCriteriaLength(searchCriteria);
       fail("No validation exception raised when expected because the search criteria is empty.");
@@ -166,7 +174,7 @@ public class ValidationServiceTest {
 
   @Test
   public void validateSearchCriteriaLengthNull() {
-
+    // Act and Assert
     try {
       validationService.validateMinSearchCriteriaLength(null);
       fail("No validation exception raised when expected because the search criteria is empty.");
@@ -179,10 +187,11 @@ public class ValidationServiceTest {
 
   @Test
   public void validateMinSearchTermLengthTooSmallError() {
-
+    // Arrange
     final List<String> searchCriteria = new ArrayList<>();
     searchCriteria.add("12");
 
+    // Act and Assert
     try {
       validationService.validateMinSearchCriteriaLength(searchCriteria);
       fail(

--- a/application/app/src/test/java/uk/nhs/digital/uec/api/service/mock/FuzzyServiceSearchServiceMock.java
+++ b/application/app/src/test/java/uk/nhs/digital/uec/api/service/mock/FuzzyServiceSearchServiceMock.java
@@ -1,4 +1,4 @@
-package uk.nhs.digital.uec.api.service.mockimpl;
+package uk.nhs.digital.uec.api.service.mock;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -6,9 +6,9 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import uk.nhs.digital.uec.api.model.DosService;
 import uk.nhs.digital.uec.api.service.FuzzyServiceSearchServiceInterface;
-import uk.nhs.digital.uec.api.utils.MockDosServicesUtil;
+import uk.nhs.digital.uec.api.util.MockDosServicesUtil;
 
-@Profile("mock")
+@Profile("test")
 @Service
 public class FuzzyServiceSearchServiceMock implements FuzzyServiceSearchServiceInterface {
 

--- a/application/app/src/test/java/uk/nhs/digital/uec/api/util/MockDosServicesUtil.java
+++ b/application/app/src/test/java/uk/nhs/digital/uec/api/util/MockDosServicesUtil.java
@@ -1,4 +1,4 @@
-package uk.nhs.digital.uec.api.utils;
+package uk.nhs.digital.uec.api.util;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -12,14 +12,21 @@ public class MockDosServicesUtil {
   public static Map<Integer, DosService> mockDosServices = new HashMap<>();
 
   static {
-    mockDosServices.put(1, buildMockService1());
+    mockDosServices.put(1, buildMockService1(1));
     mockDosServices.put(2, buildMockService2());
+    addMockServices(20);
   }
 
-  private static DosService buildMockService1() {
+  public static void addMockServices(int numberToAdd) {
+    for (int i = mockDosServices.size() + 1; i <= numberToAdd; i++) {
+      mockDosServices.put(i, buildMockService1(i));
+    }
+  }
+
+  private static DosService buildMockService1(int identifier) {
 
     List<String> address = new ArrayList<>();
-    address.add("1 Service Street");
+    address.add(identifier + " Service Street");
     address.add("Service town");
     address.add("Exmouth");
 
@@ -28,13 +35,13 @@ public class MockDosServicesUtil {
     referralRoles.add("Role 2");
 
     return new DosService.DosServiceBuilder()
-        .id(1)
-        .uIdentifier(1)
-        .name("service1")
-        .publicName("Public Service Name 1")
+        .id(identifier)
+        .uIdentifier(identifier)
+        .name("service" + identifier)
+        .publicName("Public Service Name " + identifier)
         .type("Type 1")
         .typeId(1)
-        .odsCode("odscode1")
+        .odsCode("odscode" + identifier)
         .capacityStatus("GREEN")
         .address(address)
         .postcode("EX7 8PR")

--- a/application/app/src/test/java/uk/nhs/digital/uec/api/util/PropertySourceResolver.java
+++ b/application/app/src/test/java/uk/nhs/digital/uec/api/util/PropertySourceResolver.java
@@ -8,4 +8,7 @@ public class PropertySourceResolver {
 
   @Value("${api.endpoint}")
   public String endpointUrl;
+
+  @Value("${param.services.max_num_services_to_return}")
+  public int maxNumServicesToReturn;
 }

--- a/application/app/src/test/resources/application.yaml
+++ b/application/app/src/test/resources/application.yaml
@@ -1,13 +1,13 @@
 server:
-  port: 9095
+  port: ${SERVER_PORT}
 
 api:
-  endpoint: http://localhost:9095/dosapi/dosservices/v0.0.1/services/byfuzzysearch
+  endpoint: ${URL}
 
 param:
-  version: 0.0.1
+  version: ${VERSION}
   validation:
-    min_search_term_length: 3
-    max_search_criteria: 5
+    min_search_term_length: ${MIN_SEARCH_TERM_LENGTH}
+    max_search_criteria: ${MAX_SEARCH_CRITERIA}
   services:
-    max_num_services_to_return: 20
+    max_num_services_to_return: ${MAX_NUM_SERVICES_TO_RETURN}

--- a/application/app/src/test/resources/application.yaml
+++ b/application/app/src/test/resources/application.yaml
@@ -1,0 +1,13 @@
+server:
+  port: 9095
+
+api:
+  endpoint: http://localhost:9095/dosapi/dosservices/v0.0.1/services/byfuzzysearch
+
+param:
+  version: 0.0.1
+  validation:
+    min_search_term_length: 3
+    max_search_criteria: 5
+  services:
+    max_num_services_to_return: 20

--- a/build/automation/var/profile/local.mk
+++ b/build/automation/var/profile/local.mk
@@ -2,3 +2,10 @@
 
 # ==============================================================================
 # Service variables
+SPRING_PROFILES_ACTIVE := test,prod
+URL := "http://localhost:9095/dosapi/dosservices/v0.0.1/services/byfuzzysearch"
+SERVER_PORT := 9095
+VERSION := v0.0.1
+MIN_SEARCH_TERM_LENGTH := 2
+MAX_SEARCH_CRITERIA := 5
+MAX_NUM_SERVICES_TO_RETURN := 20

--- a/build/docker/docker-compose.yml
+++ b/build/docker/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     networks:
       default:
         aliases:
-          - elasticsearch.sfs.local
+          - fuzzysearch.sfs.local
 
   elasticsearch:
     image: nhsd/elasticsearch:$DOCKER_LIBRARY_ELASTICSEARCH_VERSION
@@ -30,7 +30,7 @@ services:
     networks:
       default:
         aliases:
-          - fuzzysearch.sfs.local
+          - elasticsearch.sfs.local
 
 networks:
   default:

--- a/build/docker/docker-compose.yml
+++ b/build/docker/docker-compose.yml
@@ -1,9 +1,9 @@
 version: "3.7"
 
 services:
-  fuzzysearchapi:
+  fuzzysearch:
     image: 461183108257.dkr.ecr.eu-west-2.amazonaws.com/uec-dos-api/sfs/dos-service-fuzzy-search-api:latest
-    container_name: dos-service-fuzzy-search-api
+    container_name: fuzzysearch
     environment:
       SPRING_PROFILES_ACTIVE: test
       PARAM.SERVICE.MAX_NUM_SERVICES_TO_RETURN: 20
@@ -18,9 +18,9 @@ services:
         aliases:
           - dos-service-fuzzy-search-api.sf.test
 
-  elasticsearchservice:
+  elasticsearch:
     image: elasticsearch:$DOCKER_ELASTICSEARCH_VERSION
-    container_name: dos-service-fuzzy-search-api-elasticsearch
+    container_name: elasticsearch
     hostname: elasticsearch
     user: elasticsearch
     environment:

--- a/build/docker/docker-compose.yml
+++ b/build/docker/docker-compose.yml
@@ -5,14 +5,37 @@ services:
     image: 461183108257.dkr.ecr.eu-west-2.amazonaws.com/uec-dos-api/sfs/dos-service-fuzzy-search-api:latest
     container_name: dos-service-fuzzy-search-api
     environment:
-      SPRING_PROFILES_ACTIVE: mock
+      SPRING_PROFILES_ACTIVE: test
+      PARAM.SERVICE.MAX_NUM_SERVICES_TO_RETURN: 20
       PARAM.VERSION: v0.0.1
       PARAM.VALIDATION.MIN_SEARCH_STRING_LENGTH: 3
       PARAM.VALIDATION.MAX_SEARCH_CRITERIA: 10
-      PARAM.BUSINESS.SEARCH_CRITERIA_DELIMITER: ","
     ports:
       - 9095:9095
     command: ["java", "-jar", "/application/dos-service-fuzzy-search-api.jar"]
+    networks:
+      default:
+        aliases:
+          - dos-service-fuzzy-search-api.sf.test
+
+  elasticsearchservice:
+    image: elasticsearch:$DOCKER_ELASTICSEARCH_VERSION
+    container_name: dos-service-fuzzy-search-api-elasticsearch
+    hostname: elasticsearch
+    user: elasticsearch
+    environment:
+      ES_JAVA_OPTS: "-Xms64m -Xmx128m"
+    ports:
+      - "9200:9200"
+    command: >
+      /bin/bash -c "
+        elasticsearch \
+          -E discovery.type=single-node \
+          -E http.port=9200 \
+          -E http.cors.enabled=true \
+          -E http.cors.allow-origin=http://localhost:1358,http://127.0.0.1:1358 \
+          -E http.cors.allow-headers=X-Requested-With,X-Auth-Token,Content-Type,Content-Length,Authorization \
+          -E http.cors.allow-credentials=true; "
     networks:
       default:
         aliases:

--- a/build/docker/docker-compose.yml
+++ b/build/docker/docker-compose.yml
@@ -19,12 +19,9 @@ services:
   #         - dos-service-fuzzy-search-api.sf.test
 
   elasticsearch:
-    image: nhsd/elasticsearch:latest
+    image: nhsd/elasticsearch:$DOCKER_LIBRARY_ELASTICSEARCH_VERSION
     container_name: elasticsearch
     hostname: elasticsearch
-    user: elasticsearch
-    environment:
-      ES_JAVA_OPTS: "-Xms64m -Xmx128m"
     ports:
       - "9200:9200"
     command: ["elasticsearch"]

--- a/build/docker/docker-compose.yml
+++ b/build/docker/docker-compose.yml
@@ -1,22 +1,24 @@
 version: "3.7"
 
 services:
-  # fuzzysearch:
-  #   image: 461183108257.dkr.ecr.eu-west-2.amazonaws.com/uec-dos-api/sfs/dos-service-fuzzy-search-api:latest
-  #   container_name: fuzzysearch
-  #   environment:
-  #     SPRING_PROFILES_ACTIVE: test
-  #     PARAM.SERVICE.MAX_NUM_SERVICES_TO_RETURN: 20
-  #     PARAM.VERSION: v0.0.1
-  #     PARAM.VALIDATION.MIN_SEARCH_STRING_LENGTH: 3
-  #     PARAM.VALIDATION.MAX_SEARCH_CRITERIA: 10
-  #   ports:
-  #     - 9095:9095
-  #   command: ["java", "-jar", "/application/dos-service-fuzzy-search-api.jar"]
-  #   networks:
-  #     default:
-  #       aliases:
-  #         - dos-service-fuzzy-search-api.sf.test
+  fuzzysearch:
+    image: 461183108257.dkr.ecr.eu-west-2.amazonaws.com/uec-dos-api/sfs/dos-service-fuzzy-search-api:latest
+    container_name: fuzzysearch
+    environment:
+      SPRING_PROFILES_ACTIVE: $SPRING_PROFILES_ACTIVE
+      URL: $URL
+      SERVER_PORT: $SERVER_PORT
+      VERSION: $VERSION
+      MIN_SEARCH_TERM_LENGTH: $MIN_SEARCH_TERM_LENGTH
+      MAX_SEARCH_CRITERIA: $MAX_SEARCH_CRITERIA
+      MAX_NUM_SERVICES_TO_RETURN: $MAX_NUM_SERVICES_TO_RETURN
+    ports:
+      - 9095:9095
+    command: ["java", "-jar", "/application/dos-service-fuzzy-search-api.jar"]
+    networks:
+      default:
+        aliases:
+          - elasticsearch.sfs.local
 
   elasticsearch:
     image: nhsd/elasticsearch:$DOCKER_LIBRARY_ELASTICSEARCH_VERSION
@@ -28,7 +30,7 @@ services:
     networks:
       default:
         aliases:
-          - dos-service-fuzzy-search-api.sf.test
+          - fuzzysearch.sfs.local
 
 networks:
   default:

--- a/build/docker/docker-compose.yml
+++ b/build/docker/docker-compose.yml
@@ -1,25 +1,25 @@
 version: "3.7"
 
 services:
-  fuzzysearch:
-    image: 461183108257.dkr.ecr.eu-west-2.amazonaws.com/uec-dos-api/sfs/dos-service-fuzzy-search-api:latest
-    container_name: fuzzysearch
-    environment:
-      SPRING_PROFILES_ACTIVE: test
-      PARAM.SERVICE.MAX_NUM_SERVICES_TO_RETURN: 20
-      PARAM.VERSION: v0.0.1
-      PARAM.VALIDATION.MIN_SEARCH_STRING_LENGTH: 3
-      PARAM.VALIDATION.MAX_SEARCH_CRITERIA: 10
-    ports:
-      - 9095:9095
-    command: ["java", "-jar", "/application/dos-service-fuzzy-search-api.jar"]
-    networks:
-      default:
-        aliases:
-          - dos-service-fuzzy-search-api.sf.test
+  # fuzzysearch:
+  #   image: 461183108257.dkr.ecr.eu-west-2.amazonaws.com/uec-dos-api/sfs/dos-service-fuzzy-search-api:latest
+  #   container_name: fuzzysearch
+  #   environment:
+  #     SPRING_PROFILES_ACTIVE: test
+  #     PARAM.SERVICE.MAX_NUM_SERVICES_TO_RETURN: 20
+  #     PARAM.VERSION: v0.0.1
+  #     PARAM.VALIDATION.MIN_SEARCH_STRING_LENGTH: 3
+  #     PARAM.VALIDATION.MAX_SEARCH_CRITERIA: 10
+  #   ports:
+  #     - 9095:9095
+  #   command: ["java", "-jar", "/application/dos-service-fuzzy-search-api.jar"]
+  #   networks:
+  #     default:
+  #       aliases:
+  #         - dos-service-fuzzy-search-api.sf.test
 
   elasticsearch:
-    image: elasticsearch:$DOCKER_ELASTICSEARCH_VERSION
+    image: nhsd/elasticsearch:latest
     container_name: elasticsearch
     hostname: elasticsearch
     user: elasticsearch
@@ -27,15 +27,7 @@ services:
       ES_JAVA_OPTS: "-Xms64m -Xmx128m"
     ports:
       - "9200:9200"
-    command: >
-      /bin/bash -c "
-        elasticsearch \
-          -E discovery.type=single-node \
-          -E http.port=9200 \
-          -E http.cors.enabled=true \
-          -E http.cors.allow-origin=http://localhost:1358,http://127.0.0.1:1358 \
-          -E http.cors.allow-headers=X-Requested-With,X-Auth-Token,Content-Type,Content-Length,Authorization \
-          -E http.cors.allow-credentials=true; "
+    command: ["elasticsearch"]
     networks:
       default:
         aliases:


### PR DESCRIPTION
This PR implements the API service layer with a stubbed repository (elasticsearch) layer. The repository layer will be implemented in a further iteration of the development.

The implemented service layer bridges the gap between the controller and repository layers, providing a method that passes the search terms to the elasticsearch repository layer. The method restricts the number of services returned by a configurable amount.

An elasticsearch container is also added to the docker-compose file to spin up an elasticsearch container for use with local development.