### PR TITLE
SFD-XXXX Profile Service ETL Trigger Timer

### DIFF
--- a/build/automation/var/profile/dev.mk
+++ b/build/automation/var/profile/dev.mk
@@ -40,6 +40,7 @@ ADDRESS_PRIORITY := 2
 POSTCODE_PRIORITY := 0
 NAME_PUBLIC_PRIORITY := 4
 
+
 # ==============================================================================
 # Infrastructure variables
 
@@ -59,8 +60,18 @@ TF_VAR_es_snapshot_role := $(TF_VAR_service_prefix)-elasticsearch-snapshot
 TF_VAR_es_domain_name := sfs-$(PROFILE)
 TF_VAR_service_etl_logging_level := INFO
 TF_VAR_service_etl_sns_logging_level := INFO
-
 TF_VAR_service_etl_sns_email := service-etl-logs-aaaaepsnsym5hcy3wa6vxo4aya@a2si.slack.com
+
+# See : https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
+# Config for the cron job trigger for the service etl set to be:
+# 6am Monday - Friday (This is because we dont want the service to be running every 4 minutes in non prod)
+# For prod we need to set cron(0/4 * * * ? *) (Every 4 minutes)
+TF_VAR_service_etl_cron_timer_minutes := 0
+TF_VAR_service_etl_cron_timer_hours := 6
+TF_VAR_service_etl_cron_timer_day_of_month := ?
+TF_VAR_service_etl_cron_timer_month := *
+TF_VAR_service_etl_cron_timer_day_of_week := MON-FRI
+TF_VAR_service_etl_cron_timer_year := *
 
 # Service Data files
 SERVICE_DATA_FILE := create_all_services_dev.sh

--- a/infrastructure/stacks/service_etl/locals.tf
+++ b/infrastructure/stacks/service_etl/locals.tf
@@ -31,7 +31,7 @@ locals {
 
   service_etl_cloudwatch_event_name            = "service-finder-${var.profile}-service-etl-rule"
   service_etl_cloudwatch_event_description     = "Timer to run the service-etl every 4 minutes"
-  service_etl_cloudwatch_event_cron_expression = "cron(0/4 * * * ? *)"
+  service_etl_cloudwatch_event_cron_expression = "cron(${var.service_etl_cron_timer_minutes} ${var.service_etl_cron_timer_hours} ${var.service_etl_cron_timer_day_of_month} ${var.service_etl_cron_timer_month} ${var.service_etl_cron_timer_day_of_week} ${var.service_etl_cron_timer_year})"
   service_etl_cloudwatch_event_target          = "lambda"
   service_etl_cloudwatch_event_statement       = "AllowExecutionFromCloudWatch"
   service_etl_cloudwatch_event_action          = "lambda:InvokeFunction"

--- a/infrastructure/stacks/service_etl/variables.tf
+++ b/infrastructure/stacks/service_etl/variables.tf
@@ -36,3 +36,10 @@ variable "service_etl_sns_email" { description = "email desitination for critica
 variable "service_etl_sns_logging_level" { description = "Logging level for service_etl_sns lambda" }
 
 variable "service_etl_logging_level" { description = "Logging level for service_etl lambda" }
+
+variable "service_etl_cron_timer_minutes" { description = "cron timer for the minutes service etl should trigger" }
+variable "service_etl_cron_timer_hours" { description = "cron timer for the hours service etl should trigger" }
+variable "service_etl_cron_timer_day_of_month" { description = "cron timer for the day of the month service etl should trigger" }
+variable "service_etl_cron_timer_month" { description = "cron timer for the month service etl should trigger" }
+variable "service_etl_cron_timer_day_of_week" { description = "cron timer for the day of the week service etl should trigger" }
+variable "service_etl_cron_timer_year" { description = "cron timer for the year service etl should trigger" }


### PR DESCRIPTION
Added the service etl trigger cron expression to the profile files.
There is an issue in the terraform dev ops scripts that wont allow spaces in variables, therefore the cron expression has had to be split apart into its individual parameters to be passed into the terraform. This is not an issue as it makes the cron timer much more configurable without the worry of syntax