### PR TITLE
SFD-4105 Infrastructure security changes following review

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,12 @@ provision: # Provision environment - mandatory: PROFILE=[name]
 	make prepare-lambda-deployment
 	make terraform-apply-auto-approve STACK=$(INFRASTRUCTURE_STACKS) PROFILE=$(PROFILE)
 
+plan_auth: # Plan environment - mandatory: PROFILE=[name]
+	make terraform-plan STACK=$(INFRASTRUCTURE_STACKS_AUTH) PROFILE=$(PROFILE)
+
+provision_auth: # Provision environment - mandatory: PROFILE=[name]
+	make terraform-apply-auto-approve STACK=$(INFRASTRUCTURE_STACKS_AUTH) PROFILE=$(PROFILE)
+
 project-populate-cognito: ## Populate cognito - optional: PROFILE=nonprod|prod,AWS_ROLE=Developer
 	if $(ADD_DEFAULT_COGNITO_USERS); then \
 		eval "$$(make aws-assume-role-export-variables)"

--- a/build/automation/var/profile/dev.mk
+++ b/build/automation/var/profile/dev.mk
@@ -52,7 +52,9 @@ CHECK_DEPLOYMENT_POLL_INTERVAL := 10
 # Infrastructure variables
 
 DEPLOYMENT_STACKS = application
-INFRASTRUCTURE_STACKS = elasticsearch,authentication,service_etl
+INFRASTRUCTURE_STACKS = elasticsearch,service_etl
+INFRASTRUCTURE_STACKS_DESTROY = service_etl,elasticsearch
+INFRASTRUCTURE_STACKS_AUTH = authentication
 SERVICE_PREFIX := $(PROJECT_GROUP_SHORT)-$(PROJECT_NAME_SHORT)-$(ENVIRONMENT)
 TF_VAR_service_prefix := $(PROJECT_GROUP_SHORT)-$(PROJECT_NAME_SHORT)-$(ENVIRONMENT)
 

--- a/build/jenkins/Jenkinsfile.deployment
+++ b/build/jenkins/Jenkinsfile.deployment
@@ -46,24 +46,10 @@ pipeline {
         }
       }
     }
-    stage("Populate Cognito Pool"){
-      steps {
-        script {
-          sh "make project-populate-cognito PROFILE=${env.PROFILE}"
-        }
-      }
-    }
     stage("Provision Infrastructure") {
       steps {
         script {
           sh "make provision PROFILE=${env.PROFILE}"
-        }
-      }
-    }
-    stage("Populate Search DB") {
-      steps {
-        script {
-          echo "to do"
         }
       }
     }
@@ -103,11 +89,9 @@ pipeline {
       }
     }
   }
-
   post {
     always { sh "make clean" }
     success { sh "make pipeline-on-success" }
     failure { sh "make pipeline-on-failure" }
   }
-
 }

--- a/build/jenkins/Jenkinsfile.deployment.auth
+++ b/build/jenkins/Jenkinsfile.deployment.auth
@@ -1,0 +1,63 @@
+pipeline {
+  /*
+    Description: Deployment pipeline
+   */
+
+  agent { label "jenkins-slave" }
+
+  options {
+    buildDiscarder(logRotator(daysToKeepStr: "7", numToKeepStr: "13"))
+    disableConcurrentBuilds()
+    parallelsAlwaysFailFast()
+    timeout(time: 30, unit: "MINUTES")
+  }
+
+  environment {
+    PROFILE = "dev"
+  }
+
+  stages {
+    stage('Show Variables') {
+      steps {
+        script {
+          sh 'make devops-print-variables'
+        }
+      }
+    }
+    stage('Prepare') {
+      steps {
+        script {
+          sh "make prepare"
+        }
+      }
+    }
+    stage("Plan Infrastructure") {
+      steps {
+        script {
+          sh "make plan_auth PROFILE=${env.PROFILE}"
+        }
+      }
+    }
+    stage("Provision Infrastructure") {
+      steps {
+        script {
+          sh "make provision_auth PROFILE=${env.PROFILE}"
+        }
+      }
+    }
+    stage("Populate Cognito Pool"){
+      steps {
+        script {
+          sh "make project-populate-cognito PROFILE=${env.PROFILE}"
+        }
+      }
+    }
+  }
+
+  post {
+    always { sh "make clean" }
+    success { sh "make pipeline-on-success" }
+    failure { sh "make pipeline-on-failure" }
+  }
+
+}

--- a/infrastructure/modules/elasticsearch/elasticsearch.tf
+++ b/infrastructure/modules/elasticsearch/elasticsearch.tf
@@ -3,7 +3,7 @@ resource "aws_elasticsearch_domain" "elasticsearch_service" {
   elasticsearch_version = var.elasticsearch_version
 
   vpc_options {
-    subnet_ids         = [var.public_subnets_ids[0]]
+    subnet_ids         = [var.private_subnets_ids[0]]
     security_group_ids = [aws_security_group.elasticsearch.id]
   }
 
@@ -20,6 +20,11 @@ resource "aws_elasticsearch_domain" "elasticsearch_service" {
     }
   }
 
+  domain_endpoint_options {
+    enforce_https       = true
+    tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+  }
+
   ebs_options {
     ebs_enabled = true
     volume_size = var.volume_size_gb
@@ -34,7 +39,8 @@ resource "aws_elasticsearch_domain" "elasticsearch_service" {
   }
 
   advanced_options = {
-    "rest.action.multi.allow_explicit_index" = true
+    "override_main_response_version"         = "false"
+    "rest.action.multi.allow_explicit_index" = "true"
   }
 
   log_publishing_options {

--- a/infrastructure/modules/elasticsearch/locals.tf
+++ b/infrastructure/modules/elasticsearch/locals.tf
@@ -1,6 +1,6 @@
 locals {
   availability_zone_count_list = var.zone_awareness_enabled ? [var.availability_zone_count] : []
 
-  subnet_ids = var.instance_count == "1" ? [var.public_subnets_ids[0]] : var.public_subnets_ids
+  subnet_ids = var.instance_count == "1" ? [var.private_subnets_ids[0]] : var.private_subnets_ids
 
 }

--- a/infrastructure/modules/elasticsearch/security_groups.tf
+++ b/infrastructure/modules/elasticsearch/security_groups.tf
@@ -28,13 +28,3 @@ resource "aws_security_group_rule" "allow_in_from_eks_worker" {
   security_group_id        = aws_security_group.elasticsearch.id
   description              = "Allow access in from Eks-worker to elasticsearch"
 }
-
-resource "aws_security_group_rule" "allow_in_from_vpn" {
-  type                     = "ingress"
-  from_port                = 443
-  to_port                  = 443
-  protocol                 = "tcp"
-  source_security_group_id = var.vpn_security_group_id
-  security_group_id        = aws_security_group.elasticsearch.id
-  description              = "Allow access in from VPN to elasticsearch"
-}

--- a/infrastructure/modules/elasticsearch/variables.tf
+++ b/infrastructure/modules/elasticsearch/variables.tf
@@ -20,17 +20,13 @@ variable "vpc_id" {
   description = "VPC identifier."
 }
 
-variable "public_subnets_ids" {
+variable "private_subnets_ids" {
   default     = []
-  description = "List of public subnet ids for the VPC."
+  description = "List of private subnet ids for the VPC."
 }
 
 variable "eks_security_group_id" {
   description = "Id of the EKS security group identifier."
-}
-
-variable "vpn_security_group_id" {
-  description = "Id of the VPN security group identifier."
 }
 
 # Elasticsearch variables

--- a/infrastructure/stacks/authentication/locals.tf
+++ b/infrastructure/stacks/authentication/locals.tf
@@ -8,7 +8,7 @@ locals {
   }
 
   sf_cognito = {
-    cognito_pool_name = "${var.cognito_user_pool}"
+    cognito_pool_name = var.cognito_user_pool
   }
 
 }

--- a/infrastructure/stacks/elasticsearch/data.tf
+++ b/infrastructure/stacks/elasticsearch/data.tf
@@ -7,24 +7,6 @@ data "terraform_remote_state" "vpc" {
   }
 }
 
-data "terraform_remote_state" "route53" {
-  backend = "s3"
-  config = {
-    bucket = var.terraform_platform_state_store
-    key    = var.route53_terraform_state_key
-    region = var.aws_region
-  }
-}
-
-data "terraform_remote_state" "security-groups" {
-  backend = "s3"
-  config = {
-    bucket = var.terraform_platform_state_store
-    key    = var.security_groups_terraform_state_key
-    region = var.aws_region
-  }
-}
-
 data "terraform_remote_state" "security-groups-k8s" {
   backend = "s3"
   config = {

--- a/infrastructure/stacks/elasticsearch/locals.tf
+++ b/infrastructure/stacks/elasticsearch/locals.tf
@@ -11,7 +11,7 @@ locals {
   sfs_elasticsearch = {
     component               = "elasticsearch"
     availability_zone_count = var.es_availability_zone_count
-    elasticsearch_version   = "7.7"
+    elasticsearch_version   = "OpenSearch_1.1"
     encrypt_at_rest         = true
     node_to_node_encryption = true
     instance_count          = var.es_instance_count

--- a/infrastructure/stacks/elasticsearch/main.tf
+++ b/infrastructure/stacks/elasticsearch/main.tf
@@ -1,15 +1,14 @@
 # Elasticsearch
 module "sfs_elasticsearch" {
-  source                  = "../../modules/elasticsearch"
-  service_prefix          = var.service_prefix
-  service_prefix_short    = var.service_prefix
-  es_domain_name          = var.es_domain_name
-  es_snapshot_bucket      = var.es_snapshot_bucket
-  es_snapshot_role        = var.es_snapshot_role
-  vpc_id                  = data.terraform_remote_state.vpc.outputs.vpc_id
-  public_subnets_ids      = data.terraform_remote_state.vpc.outputs.public_subnets
-  eks_security_group_id   = data.terraform_remote_state.security-groups-k8s.outputs.eks_worker_additional_sg_id
-  vpn_security_group_id   = data.terraform_remote_state.security-groups.outputs.vpn_main_sg_id
+  source                = "../../modules/elasticsearch"
+  service_prefix        = var.service_prefix
+  service_prefix_short  = var.service_prefix
+  es_domain_name        = var.es_domain_name
+  es_snapshot_bucket    = var.es_snapshot_bucket
+  es_snapshot_role      = var.es_snapshot_role
+  vpc_id                = data.terraform_remote_state.vpc.outputs.vpc_id
+  private_subnets_ids   = data.terraform_remote_state.vpc.outputs.private_subnets
+  eks_security_group_id = data.terraform_remote_state.security-groups-k8s.outputs.eks_worker_additional_sg_id
   availability_zone_count = local.sfs_elasticsearch["availability_zone_count"]
   component               = local.sfs_elasticsearch["component"]
   elasticsearch_version   = local.sfs_elasticsearch["elasticsearch_version"]

--- a/infrastructure/stacks/elasticsearch/variables.tf
+++ b/infrastructure/stacks/elasticsearch/variables.tf
@@ -31,10 +31,6 @@ variable "terraform_platform_state_store" { description = "Name of the S3 bucket
 
 variable "vpc_terraform_state_key" { description = "The VPC key in the terraform state bucket" }
 
-variable "route53_terraform_state_key" { description = "The Route53 key in the terraform state bucket" }
-
-variable "security_groups_terraform_state_key" { description = "The security groups key in the terraform state bucket" }
-
 variable "security_groups_k8s_terraform_state_key" { description = "The k8s security groups key in the terraform state bucket" }
 
 variable "programme" { description = "The programme tag" }

--- a/infrastructure/stacks/service_etl/data.tf
+++ b/infrastructure/stacks/service_etl/data.tf
@@ -39,7 +39,3 @@ data "aws_secretsmanager_secret" "dos_read_replica_secret_name" {
 data "aws_elasticsearch_domain" "elasticsearch" {
   domain_name = var.es_domain_name
 }
-
-data "aws_cloudwatch_log_group" "service_etl_log_group" {
-  name = "/aws/lambda/${local.service_etl_function_name}"
-}

--- a/infrastructure/stacks/service_etl/locals.tf
+++ b/infrastructure/stacks/service_etl/locals.tf
@@ -27,7 +27,6 @@ locals {
 
   service_etl_policy_name = "${var.service_prefix}-service-etl"
 
-  rds_data_read_only_access_policy_arn = "arn:aws:iam::aws:policy/AmazonRDSReadOnlyAccess"
 
   service_etl_cloudwatch_event_name            = "${var.service_prefix}-service-etl-rule"
   service_etl_cloudwatch_event_description     = "Timer to run the service-etl every 4 minutes"


### PR DESCRIPTION
Highlights:

- Assigned ETLs their own SGs and set up ingress and egress rules to allow these security groups access to the read replica RDS, and remove read replica RDS SG from ETLs
- Spin up elasticsearch in private subnet, not pubilc
- Upgrade version of elasticsearch to opensearch_1.1
- Apply HTTP encryption to elasticsearch
- Removed redundant data lookups and IAM policy attachments